### PR TITLE
Adds iOS permissions

### DIFF
--- a/app/App_Resources/iOS/Info.plist
+++ b/app/App_Resources/iOS/Info.plist
@@ -62,5 +62,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>${PRODUCT_NAME} needs access to your camera</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>${PRODUCT_NAME} need to add to your Photos Library</string>
 </dict>
 </plist>


### PR DESCRIPTION
iOS 10+ needs key/string pairs in Info.plist to use the camera and add to photo library.